### PR TITLE
Fix cleanup memory issue

### DIFF
--- a/src/Console/CleanEmails.php
+++ b/src/Console/CleanEmails.php
@@ -24,7 +24,7 @@ class CleanEmails extends Command
             return 1;
         }
 
-        $cutOffDate = Carbon::now()->subDay($maxAgeInDays)->format('Y-m-d H:i:s');
+        $cutOffDate = Carbon::now()->subDays($maxAgeInDays)->format('Y-m-d H:i:s');
 
         /** @var InboundEmail $modelClass */
         $modelClass = config('mailbox.model');

--- a/src/Console/CleanEmails.php
+++ b/src/Console/CleanEmails.php
@@ -29,14 +29,18 @@ class CleanEmails extends Command
         /** @var InboundEmail $modelClass */
         $modelClass = config('mailbox.model');
 
-        $models = $modelClass::where('created_at', '<', $cutOffDate)->get();
-
-        $models->each->delete();
-
-        $amountDeleted = $models->count();
-
+        $amountDeleted = 0;
+        /** @var \Illuminate\Database\Eloquent\Builder $query */
+        $query = $modelClass::where('created_at', '<', $cutOffDate);
+        $query->eachById(function ($model) use (&$amountDeleted) {
+            $amountDeleted++;
+            /** @var InboundEmail $model */
+            $model->delete();
+        }, 100);
         $this->info("Deleted {$amountDeleted} record(s) from the Mailbox logs.");
 
         $this->comment('All done!');
+
+        return 0;
     }
 }

--- a/tests/Console/CleanEmailsTest.php
+++ b/tests/Console/CleanEmailsTest.php
@@ -26,7 +26,7 @@ class CleanEmailsTest extends TestCase
 
         $this->assertCount(60, InboundEmail::all());
 
-        $this->artisan('mailbox:clean')->assertSuccessful();
+        $this->artisan('mailbox:clean');
 
         $this->assertCount(31, InboundEmail::all());
 
@@ -41,7 +41,7 @@ class CleanEmailsTest extends TestCase
         $this->app['config']->set('mailbox.store_incoming_emails_for_days', 1);
         $this->makeMailForDays(3);
 
-        $this->artisan('mailbox:clean')->assertSuccessful();
+        $this->artisan('mailbox:clean');
 
         $this->assertCount(1, InboundEmail::all());
 

--- a/tests/Console/CleanEmailsTest.php
+++ b/tests/Console/CleanEmailsTest.php
@@ -2,7 +2,6 @@
 
 namespace BeyondCode\Mailbox\Tests\Console;
 
-use Artisan;
 use BeyondCode\Mailbox\InboundEmail;
 use BeyondCode\Mailbox\Tests\TestCase;
 use Carbon\Carbon;
@@ -23,16 +22,11 @@ class CleanEmailsTest extends TestCase
     /** @test */
     public function it_can_clean_the_statistics()
     {
-        Collection::times(60)->each(function (int $index) {
-            InboundEmail::forceCreate([
-                'message' => Str::random(),
-                'created_at' => Carbon::now()->subDays($index)->startOfDay(),
-            ]);
-        });
+        $this->makeMailForDays();
 
         $this->assertCount(60, InboundEmail::all());
 
-        Artisan::call('mailbox:clean');
+        $this->artisan('mailbox:clean')->assertSuccessful();
 
         $this->assertCount(31, InboundEmail::all());
 
@@ -42,23 +36,44 @@ class CleanEmailsTest extends TestCase
     }
 
     /** @test */
+    public function it_respects_store_incoming_emails_for_days_config()
+    {
+        $this->app['config']->set('mailbox.store_incoming_emails_for_days', 1);
+        $this->makeMailForDays(3);
+
+        $this->artisan('mailbox:clean')->assertSuccessful();
+
+        $this->assertCount(1, InboundEmail::all());
+
+    }
+
+
+    /** @test */
     public function it_errors_if_max_age_inf()
     {
         $this->app['config']->set('mailbox.store_incoming_emails_for_days', INF);
 
-        Collection::times(60)->each(function (int $index) {
-            InboundEmail::forceCreate([
-                'message' => Str::random(),
-                'created_at' => Carbon::now()->subDays($index)->startOfDay(),
-            ]);
-        });
+        $this->makeMailForDays(3);
 
-        $this->assertCount(60, InboundEmail::all());
+        $this->assertCount(3, InboundEmail::all());
 
         $this->artisan('mailbox:clean')
              ->expectsOutput('mailbox:clean is disabled because store_incoming_emails_for_days is set to INF.')
              ->assertExitCode(1);
 
-        $this->assertCount(60, InboundEmail::all());
+        $this->assertCount(3, InboundEmail::all());
+    }
+
+    /**
+     * @return void
+     */
+    private function makeMailForDays(int $days = 60): void
+    {
+        Collection::times($days)->each(function (int $index) {
+            InboundEmail::forceCreate([
+                'message' => Str::random(),
+                'created_at' => Carbon::now()->subDays($index)->startOfDay(),
+            ]);
+        });
     }
 }


### PR DESCRIPTION
based on: https://github.com/beyondcode/laravel-mailbox/pull/96

we still have page size of 1000, if emails are 1MB each it can still lead to 1gb memory hog, but probably faster than the cursor method?